### PR TITLE
feat: Rewrote to use richer data model and write kapeta config files

### DIFF
--- a/nodejs/src/ConfigFileWriter.ts
+++ b/nodejs/src/ConfigFileWriter.ts
@@ -1,6 +1,7 @@
 import FS from 'node:fs/promises';
 import { interpolateVariablesInValue } from './dotenv-interpolation';
 import * as Path from 'path';
+import {Variables} from "./variable-resolver";
 
 export type ConfigFileTemplates = {
     [path: string]: string;
@@ -36,7 +37,7 @@ export class ConfigFileWriter {
     /**
      * Renders the configuration in-memory for the provided data
      */
-    public render(data: Record<string, string>) {
+    public render(data: Variables) {
         const rendered: { [path: string]: string } = {};
         for (const path in this.templates) {
             rendered[path] = this.renderTemplate(path, data);
@@ -47,7 +48,7 @@ export class ConfigFileWriter {
     /**
      * Writes the rendered configuration to the file system for the provided data
      */
-    public async write(data: Record<string, string>) {
+    public async write(data: Variables) {
         const rendered = this.render(data);
         const entries = Object.entries(rendered);
         for (const [path, value] of entries) {
@@ -61,7 +62,7 @@ export class ConfigFileWriter {
     /**
      * Renders a single template
      */
-    public renderTemplate(path: string, data: Record<string, string>): string {
+    public renderTemplate(path: string, data: Variables): string {
         if (!(path in this.templates)) {
             throw new Error(`Template not found: ${path}`);
         }

--- a/nodejs/src/config-resolver.ts
+++ b/nodejs/src/config-resolver.ts
@@ -3,6 +3,7 @@ import FS from 'node:fs/promises';
 import YAML from 'yaml';
 import { ConfigFileTemplates, ConfigFileWriter } from './ConfigFileWriter';
 import { getAttachmentFromKapetaYML, readConfigContent } from './utils';
+import {Variables} from "./variable-resolver";
 
 /**
  * The name of the configuration file
@@ -32,7 +33,7 @@ export async function getConfigTemplatePaths(baseDir: string = process.cwd()): P
  * Renders the configuration templates from the kapeta.config.yml file in-memory
  */
 export async function renderConfigTemplates(
-    data: Record<string, string>,
+    data: Variables,
     baseDir: string = process.cwd()
 ): Promise<Record<string, string>> {
     const templates = await readConfigTemplates(baseDir);
@@ -44,7 +45,7 @@ export async function renderConfigTemplates(
 /**
  * Writes the configuration templates from the kapeta.config.yml file to the file system
  */
-export async function writeConfigTemplates(data: Record<string, string>, baseDir: string = process.cwd()) {
+export async function writeConfigTemplates(data: Variables, baseDir: string = process.cwd()) {
     const templates = await readConfigTemplates(baseDir);
     const writer = new ConfigFileWriter(templates, baseDir);
 

--- a/nodejs/src/environment.ts
+++ b/nodejs/src/environment.ts
@@ -1,3 +1,5 @@
+import {toExplodedVar, VariableInfo, Variables} from "./variable-resolver";
+
 export type EnvVarMap = { [key: string]: string | undefined };
 
 export const KAPETA_ENV_PREFIX = 'KAPETA_';
@@ -36,24 +38,24 @@ export function getKapetaEnvVars(processEnvVars: EnvVarMap = process.env): EnvVa
  * - SOME_KEY_1=2
  * - SOME_KEY_2=3
  */
-export function explodeEnvValue(key: string, value: string): EnvVarMap {
-    const envVars: EnvVarMap = {};
+export function explodeEnvValue(key: string, variable: VariableInfo): Variables {
+    const out: Variables = {};
 
-    envVars[key] = value;
+    out[key] = variable;
 
     try {
-        const parsed = JSON.parse(value);
+        const parsed = JSON.parse(variable.value);
         if (typeof parsed !== 'object') {
             // Not a JSON object or array - ignore
-            return envVars;
+            return out;
         }
 
-        Object.assign(envVars, flattenObject(parsed, `${key}_`));
+        Object.assign(out, flattenObject(parsed, `${key}_`));
     } catch (e) {
         // Not a JSON object - ignore
     }
 
-    return envVars;
+    return out;
 }
 
 /**
@@ -66,18 +68,18 @@ export function explodeEnvValue(key: string, value: string): EnvVarMap {
  * - SOME_KEY_A=1
  * - SOME_KEY_B=2
  */
-export function explodeEnvVars(processEnvVars: EnvVarMap = process.env): EnvVarMap {
-    const exploded: EnvVarMap = {};
+export function explodeEnvVars(processEnvVars: Variables): Variables {
+    const exploded: Variables = {};
     Object.entries(processEnvVars).forEach(([key, value]) => {
-        const envVars = explodeEnvValue(key, value || '');
+        const envVars = explodeEnvValue(key, value);
         Object.assign(exploded, envVars);
     });
 
     return exploded;
 }
 
-function flattenObject(obj: EnvVarMap, prefix: string = ''): EnvVarMap {
-    const flattened: EnvVarMap = {};
+function flattenObject(obj: EnvVarMap, prefix: string = ''): Variables {
+    const flattened: Variables = {};
     Object.entries(obj).forEach(([key, value]) => {
         const fullKey = (prefix + toEnvVarName(key)).toUpperCase();
         if (typeof value === 'object') {
@@ -85,7 +87,7 @@ function flattenObject(obj: EnvVarMap, prefix: string = ''): EnvVarMap {
             const flattenedChild = flattenObject(value as EnvVarMap, childPrefix);
             Object.assign(flattened, flattenedChild);
         } else {
-            flattened[fullKey] = `${value}`;
+            flattened[fullKey] = toExplodedVar(`${value}`);
         }
     });
 

--- a/nodejs/test/ConfigFileWriter.test.ts
+++ b/nodejs/test/ConfigFileWriter.test.ts
@@ -1,4 +1,5 @@
 import { ConfigFileWriter } from '../src/ConfigFileWriter';
+import {toEnvVar} from "../src/variable-resolver";
 
 describe('ConfigFileWriter', () => {
     it('can render multiple templates', () => {
@@ -7,8 +8,8 @@ describe('ConfigFileWriter', () => {
             '/tmp/bar': 'Goodbye ${BAR}',
         });
         const data = {
-            FOO: 'World',
-            BAR: 'Cruel World',
+            FOO: toEnvVar('World'),
+            BAR: toEnvVar('Cruel World'),
         };
         const rendered = configFile.render(data);
         expect(rendered).toEqual({

--- a/nodejs/test/dotenv-interpolation.test.ts
+++ b/nodejs/test/dotenv-interpolation.test.ts
@@ -1,23 +1,24 @@
-import { interpolateVariables, interpolateVariablesInValue } from '../src/dotenv-interpolation';
+import {interpolateDotEnv, interpolateVariables, interpolateVariablesInValue} from '../src/dotenv-interpolation';
+import {toEnvVar, toEnvVars, toMappedVar} from "../src/variable-resolver";
 
 describe('dotenv-interpolation', () => {
     it('can interpolate values in a string', () => {
-        const data = {
+        const data = toEnvVars({
             FOO: 'World',
             BAR: 'Cruel World',
-        };
+        });
 
         const result = interpolateVariablesInValue('Hello ${FOO}', data);
         expect(result).toEqual('Hello World');
     });
 
     it('can interpolate nested values', () => {
-        const data = {
+        const data = toEnvVars({
             TEST1: 'World',
             TEST2: '${TEST1}',
             FOO: '${TEST2}',
             BAR: 'Cruel ${FOO}',
-        };
+        });
 
         const result = interpolateVariablesInValue('Hello ${BAR}', data);
         expect(result).toEqual('Hello Cruel World');
@@ -31,25 +32,46 @@ describe('dotenv-interpolation', () => {
     });
 
     it('can interpolate default values from variable', () => {
-        const data = {
+        const data = toEnvVars({
             FOO: 'World',
-        };
+        });
 
         const result = interpolateVariablesInValue('Hello ${NOT_FOUND:-${FOO}}', data);
         expect(result).toEqual('Hello World');
     });
 
     it('can interpolate values in a map', () => {
-        const data = {
+        const data = toEnvVars({
             FOO: 'World',
             BAR: 'Cruel ${FOO}',
-        };
+        });
 
         const result = interpolateVariables(data);
 
-        expect(result).toEqual({
+        expect(result).toEqual(toEnvVars({
             FOO: 'World',
             BAR: 'Cruel World',
+        }));
+    });
+
+    it('interpolating a dot env files gives mapped variable values', () => {
+        const data = toEnvVars({
+            KAPETA_FOO: 'World',
+            KAPETA_BAR: 'Cruel ${FOO}',
+        });
+
+        const dotEnv = toEnvVars({
+            FOO: '${KAPETA_FOO}',
+            BAR: '${KAPETA_BAR}',
+        });
+
+        const result = interpolateDotEnv(dotEnv, data);
+
+        expect(result).toEqual({
+            KAPETA_FOO: toEnvVar('World'),
+            KAPETA_BAR: toEnvVar('Cruel ${FOO}'),
+            FOO: toMappedVar('World'),
+            BAR: toMappedVar('Cruel World'),
         });
     });
 });

--- a/nodejs/test/environment.test.ts
+++ b/nodejs/test/environment.test.ts
@@ -1,4 +1,5 @@
 import { explodeEnvValue, getKapetaEnvVars, toEnvVarName } from '../src/environment';
+import {toEnvVar, toExplodedVar} from "../src/variable-resolver";
 
 describe('environment', () => {
     it('can filter out all kapeta env vars from map', () => {
@@ -21,7 +22,7 @@ describe('environment', () => {
     it('can explode a JSON environment variable value into a set of environment variables', () => {
         // Arrange
         const key = 'KAPETA_ENV';
-        const value = JSON.stringify({
+        const value = toEnvVar(JSON.stringify({
             a: 1,
             b: 2,
             embedded: {
@@ -40,20 +41,20 @@ describe('environment', () => {
                     three: false,
                 },
             ],
-        });
+        }), true);
 
         const expected = {
             KAPETA_ENV: value,
-            KAPETA_ENV_A: '1',
-            KAPETA_ENV_B: '2',
-            KAPETA_ENV_EMBEDDED_C: '3',
-            KAPETA_ENV_EMBEDDED_D: '4',
-            KAPETA_ENV_ARRAY_0_ONE: 'FIRST ONE',
-            KAPETA_ENV_ARRAY_0_TWO: 'FIRST TWO',
-            KAPETA_ENV_ARRAY_0_THREE: 'true',
-            KAPETA_ENV_ARRAY_1_ONE: 'SECOND ONE',
-            KAPETA_ENV_ARRAY_1_TWO: 'SECOND TWO',
-            KAPETA_ENV_ARRAY_1_THREE: 'false',
+            KAPETA_ENV_A: toExplodedVar('1'),
+            KAPETA_ENV_B: toExplodedVar('2'),
+            KAPETA_ENV_EMBEDDED_C: toExplodedVar('3'),
+            KAPETA_ENV_EMBEDDED_D: toExplodedVar('4'),
+            KAPETA_ENV_ARRAY_0_ONE: toExplodedVar('FIRST ONE'),
+            KAPETA_ENV_ARRAY_0_TWO: toExplodedVar('FIRST TWO'),
+            KAPETA_ENV_ARRAY_0_THREE: toExplodedVar('true'),
+            KAPETA_ENV_ARRAY_1_ONE: toExplodedVar('SECOND ONE'),
+            KAPETA_ENV_ARRAY_1_TWO: toExplodedVar('SECOND TWO'),
+            KAPETA_ENV_ARRAY_1_THREE: toExplodedVar('false'),
         };
 
         const result = explodeEnvValue(key, value);
@@ -64,7 +65,7 @@ describe('environment', () => {
     it('ignores non-JSON environment variable values', () => {
         // Arrange
         const key = 'KAPETA_ENV';
-        const value = 'development';
+        const value = toEnvVar('development');
 
         const expected = {
             KAPETA_ENV: value,
@@ -78,7 +79,7 @@ describe('environment', () => {
     it('ignores non-JSON-Object environment variable values', () => {
         // Arrange
         const key = 'KAPETA_ENV';
-        const value = 'true';
+        const value = toEnvVar('true');
 
         const expected = {
             KAPETA_ENV: value,


### PR DESCRIPTION
This enables users to be more specific about which variables to use
to not hit env var length limits - and adds supporting functions
for writing the entire config to disk to avoid those same limits